### PR TITLE
Add Mach notification observer

### DIFF
--- a/CtrlKit/CtrlKit.h
+++ b/CtrlKit/CtrlKit.h
@@ -1,3 +1,4 @@
 // Umbrella header for CtrlKit.
 // Add import lines for each public header, like this: #import <CtrlKit/XXXAwesomeClass.h>
 // Don’t forget to also add them to CtrlKit_PUBLIC_HEADERS in your Makefile!
+#import <CtrlKit/IPCObserver.h>

--- a/CtrlKit/IPCObserver.h
+++ b/CtrlKit/IPCObserver.h
@@ -1,0 +1,13 @@
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface CKIPCObserver : NSObject
+
+- (instancetype)initWithNotification:(const char *)name;
+- (void)startMonitoring;
+- (void)stopMonitoring;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/CtrlKit/IPCObserver.m
+++ b/CtrlKit/IPCObserver.m
@@ -1,0 +1,54 @@
+#import "IPCObserver.h"
+#include <notify.h>
+#include <mach/mach.h>
+
+@interface CKIPCObserver () {
+    int _token;
+    mach_port_t _port;
+    dispatch_source_t _source;
+    const char *_name;
+}
+@end
+
+@implementation CKIPCObserver
+
+- (instancetype)initWithNotification:(const char *)name {
+    self = [super init];
+    if (self) {
+        _name = name;
+        _token = 0;
+        _port = MACH_PORT_NULL;
+        _source = nil;
+    }
+    return self;
+}
+
+- (void)startMonitoring {
+    if (_token) return;
+    if (notify_register_mach_port(_name, &_port, 0, &_token) == NOTIFY_STATUS_OK) {
+        _source = dispatch_source_create(DISPATCH_SOURCE_TYPE_MACH_RECV, _port, 0, dispatch_get_main_queue());
+        dispatch_source_set_event_handler(_source, ^{
+            mach_msg_header_t msg;
+            mach_msg(&msg, MACH_RCV_MSG, 0, sizeof(msg), _port, MACH_MSG_TIMEOUT_NONE, MACH_PORT_NULL);
+            NSLog(@"Received notification: %s", _name);
+        });
+        dispatch_resume(_source);
+    }
+}
+
+- (void)stopMonitoring {
+    if (_token) {
+        notify_cancel(_token);
+        _token = 0;
+    }
+    if (_source) {
+        dispatch_source_cancel(_source);
+        _source = nil;
+    }
+    if (_port != MACH_PORT_NULL) {
+        mach_port_deallocate(mach_task_self(), _port);
+        _port = MACH_PORT_NULL;
+    }
+}
+
+@end

--- a/CtrlKit/Makefile
+++ b/CtrlKit/Makefile
@@ -4,8 +4,8 @@ include $(THEOS)/makefiles/common.mk
 
 FRAMEWORK_NAME = CtrlKit
 
-CtrlKit_FILES = CtrlKit.m
-CtrlKit_PUBLIC_HEADERS = CtrlKit.h
+CtrlKit_FILES = CtrlKit.m IPCObserver.m
+CtrlKit_PUBLIC_HEADERS = CtrlKit.h IPCObserver.h
 CtrlKit_INSTALL_PATH = /Library/Frameworks
 CtrlKit_CFLAGS = -fobjc-arc
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # CtrlKit
 iOS jailbreak Framework for Tweaks and Tools
+
+## Features
+
+- `CKIPCObserver` - simple interface for monitoring mach notifications to help
+  debug inter-process communication on jailbroken devices.


### PR DESCRIPTION
## Summary
- implement `CKIPCObserver` to watch mach notifications for debugging
- expose new header via umbrella header and Makefile
- document IPC observer feature in README

## Testing
- `THEOS=../theos make` *(fails: no SDK present)*

------
https://chatgpt.com/codex/tasks/task_e_687b3e46d8548330b5f8d8044d11fecd