### PR TITLE
Fix Theos path for make

### DIFF
--- a/CtrlKit/Makefile
+++ b/CtrlKit/Makefile
@@ -1,4 +1,7 @@
 TARGET := iphone:clang:latest:7.0
+# Default to the local Theos checkout when $THEOS is not set. This
+# allows invoking `make` without having to export the variable first.
+THEOS ?= $(CURDIR)/../theos
 
 include $(THEOS)/makefiles/common.mk
 

--- a/README.md
+++ b/README.md
@@ -5,3 +5,16 @@ iOS jailbreak Framework for Tweaks and Tools
 
 - `CKIPCObserver` - simple interface for monitoring mach notifications to help
   debug inter-process communication on jailbroken devices.
+
+## Building
+
+This project uses [Theos](https://theos.dev) for its build system. A copy of
+Theos is included in this repository. If you don't already have the `THEOS`
+environment variable set, `make` will default to the bundled copy. Simply run:
+
+```sh
+make -C CtrlKit
+```
+
+If you encounter an error about missing SDKs, follow the instructions in the
+Theos documentation to obtain the necessary iOS SDK.


### PR DESCRIPTION
## Summary
- default `THEOS` to the bundled copy so `make` works out of the box
- document building steps using the bundled Theos

## Testing
- `make -C CtrlKit` *(fails: You do not have any SDKs in /workspace/CtrlKit/theos/sdks)*

------
https://chatgpt.com/codex/tasks/task_e_687b423d06108330bc471a5583caa42e