### PR TITLE
Fix make errors by adding setup script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 theos/
+ios-toolchain.tar.xz
+sdks.tar.gz
+sdks-master/

--- a/README.md
+++ b/README.md
@@ -9,15 +9,21 @@ iOS jailbreak Framework for Tweaks and Tools
 ## Building
 
 This project uses [Theos](https://theos.dev) for its build system. A copy of
-Theos is included in this repository. If you don't already have the `THEOS`
-environment variable set, `make` will default to the bundled copy. Simply run:
+Theos is included in this repository. Before building you must ensure the
+necessary SDKs and toolchains are available. Run the provided setup script once
+to download these dependencies:
+
+```sh
+./setup_theos.sh
+```
+
+If you don't already have the `THEOS` environment variable set, `make` will
+default to the bundled copy. After running the setup script you can build the
+framework with:
 
 ```sh
 make -C CtrlKit
 ```
-
-If you encounter an error about missing SDKs, follow the instructions in the
-Theos documentation to obtain the necessary iOS SDK.
 
 ## Updating
 

--- a/setup_theos.sh
+++ b/setup_theos.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+# Fetch Theos dependencies (SDKs and toolchain) for building
+set -e
+
+THEOS_DIR="$(dirname "$0")/theos"
+SDK_ARCHIVE_URL="https://github.com/theos/sdks/archive/refs/heads/master.tar.gz"
+TOOLCHAIN_URL="https://github.com/L1ghtmann/llvm-project/releases/latest/download/iOSToolchain-$(uname -m).tar.xz"
+
+mkdir -p "$THEOS_DIR"
+
+# Ensure vendor components are present
+if [ -d "$THEOS_DIR/.git" ]; then
+    git -C "$THEOS_DIR" submodule update --init --recursive
+fi
+
+# Install SDKs if missing
+if ! ls "$THEOS_DIR"/sdks/*.sdk >/dev/null 2>&1; then
+    echo "Downloading iOS SDKs..."
+    tmpdir=$(mktemp -d)
+    curl -L "$SDK_ARCHIVE_URL" | tar -xz -C "$tmpdir"
+    mkdir -p "$THEOS_DIR/sdks"
+    cp -r "$tmpdir"/sdks-*/* "$THEOS_DIR/sdks/"
+    rm -rf "$tmpdir"
+fi
+
+# Install toolchain if missing
+if [ ! -x "$THEOS_DIR/toolchain/linux/iphone/bin/clang" ]; then
+    echo "Downloading iOS toolchain..."
+    mkdir -p "$THEOS_DIR/toolchain"
+    curl -L "$TOOLCHAIN_URL" | tar -xJ -C "$THEOS_DIR/toolchain"
+fi
+
+echo "Theos dependencies are set up."


### PR DESCRIPTION
## Summary
- add a script (`setup_theos.sh`) to download required Theos SDKs and toolchain
- update README to document running the setup script before building
- ignore downloaded archives in `.gitignore`

## Testing
- `./setup_theos.sh`
- `make -C CtrlKit`

------
https://chatgpt.com/codex/tasks/task_e_687b457bf0108330b8ef7a3f478a249f